### PR TITLE
Add persistent session and secret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1329,7 @@ dependencies = [
  "diesel_logger",
  "dotenvy",
  "env_logger",
+ "hex",
  "itertools",
  "log",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ axum-sessions = "0.4.0"
 log = "0.4"
 env_logger = "0.9.0"
 diesel_logger = "0.2.0"
+hex = "0.4.3"
 
 
 [dependencies.rand]

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -20,7 +20,7 @@ use axum::{body::Body, response::{Html, Json}};
 use axum::extract::{Path, Query};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Redirect, Response};
-use axum_sessions::{async_session::MemoryStore, extractors::{ReadableSession, WritableSession}, Session, SessionLayer};
+use axum_sessions::{async_session::CookieStore, extractors::{ReadableSession, WritableSession}, Session, SessionLayer};
 use axum_sessions::async_session::blake3::Hash;
 use axum_sessions::async_session::blake3::IncrementCounter::No;
 use axum_sessions::async_session::log::trace;
@@ -33,7 +33,6 @@ use diesel::sql_types::{BoolOrNullableBool, Integer, Text};
 use diesel_logger::LoggingConnection;
 use env_logger::Env;
 use itertools::Itertools;
-use rand::Rng;
 use regex::Regex;
 use serde::Deserialize;
 
@@ -46,6 +45,7 @@ use recipemanagement::schema::course::dsl::course;
 use recipemanagement::schema::ingredient::dsl::ingredient;
 use recipemanagement::schema::recipe::primary_season;
 use recipemanagement::schema::recipe_ingredient::recipe_id;
+use recipemanagement::secret::get_secret;
 use recipemanagement::strops::extract_domain;
 use recipemanagement::templates::*;
 
@@ -57,8 +57,8 @@ async fn main() {
     // `axum::response::IntoResponse`.
 
     // A closure or a function can be used as handler.
-    let store = MemoryStore::new();
-    let secret = rand::thread_rng().gen::<[u8; 128]>();
+    let store = CookieStore::new();
+    let secret = get_secret();
     let session_layer = SessionLayer::new(store, &secret);
 
     let env = Env::default()

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -49,6 +49,9 @@ use recipemanagement::secret::get_secret;
 use recipemanagement::strops::extract_domain;
 use recipemanagement::templates::*;
 
+const SESSION_VERSION: usize = 1;
+const SESSION_VERSION_KEY: &str = "session_version";
+
 #[tokio::main]
 async fn main() {
     // Route all requests on "/" endpoint to anonymous handler.
@@ -100,9 +103,9 @@ async fn main() {
         .unwrap();
 }
 
-async fn index_handler(session: ReadableSession) -> Html<String> {
+async fn index_handler(mut session: WritableSession) -> Html<String> {
     let con = &mut database::establish_connection();
-    let maybe_user_id: Option<i32> = session.get::<i32>("user_id");
+    let maybe_user_id: Option<i32> = get_user_id(session);
     use recipemanagement::schema::course::dsl::*;
     let courses: Vec<QCourse> = course.load::<QCourse>(con).unwrap();
     let course_refs: &Vec<QCourse> = &courses;
@@ -120,7 +123,7 @@ async fn index_handler(session: ReadableSession) -> Html<String> {
     return Html(a);
 }
 
-async fn handle_course(session: ReadableSession, Path(path): Path<String>) -> Html<String> {
+async fn handle_course(mut session: WritableSession, Path(path): Path<String>) -> Html<String> {
     let cur_name = path.as_str();
     let con = &mut database::establish_connection();
     use recipemanagement::schema::course::dsl::*;
@@ -148,7 +151,7 @@ async fn handle_course(session: ReadableSession, Path(path): Path<String>) -> Ht
     let course_refs: &Vec<QCourse> = &courses;
 
     let mut tried_ids: HashSet<i32> = HashSet::new();
-    let maybe_user_id: Option<i32> = session.get::<i32>("user_id");
+    let maybe_user_id: Option<i32> = get_user_id(session);
     if maybe_user_id.is_some() {
         use recipemanagement::schema::tried::dsl::*;
         let temp = tried.filter(user_id.eq(maybe_user_id.unwrap()))
@@ -239,8 +242,8 @@ async fn handle_course(session: ReadableSession, Path(path): Path<String>) -> Ht
 }
 
 
-async fn recipe_form(session: ReadableSession, prefill: Query<RecipePrefill>) -> Response {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn recipe_form(mut session: WritableSession, prefill: Query<RecipePrefill>) -> Response {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login").into_response();
     }
@@ -288,8 +291,8 @@ struct PostRecipe {
 
 }
 
-async fn post_recipe(session: ReadableSession, Form(form): Form<PostRecipe>) -> Response {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn post_recipe(mut session: WritableSession, Form(form): Form<PostRecipe>) -> Response {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login").into_response();
     }
@@ -353,8 +356,8 @@ struct PostBook {
     booktext: String,
 }
 
-async fn book_form(session: ReadableSession) -> Response {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn book_form(mut session: WritableSession) -> Response {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login").into_response();
     }
@@ -373,8 +376,8 @@ async fn book_form(session: ReadableSession) -> Response {
     }.get()).into_response();
 }
 
-async fn post_book(session: ReadableSession, Form(form): Form<PostBook>) -> Redirect {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn post_book(mut session: WritableSession, Form(form): Form<PostBook>) -> Redirect {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login");
     }
@@ -401,9 +404,8 @@ async fn post_book(session: ReadableSession, Form(form): Form<PostBook>) -> Redi
 }
 
 
-
-async fn search_form(session: ReadableSession) -> Response {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn search_form(mut session: WritableSession) -> Response {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login").into_response();
     }
@@ -433,8 +435,8 @@ async fn search_form(session: ReadableSession) -> Response {
     }.get()).into_response();
 }
 
-async fn search_result(session: ReadableSession, Form(form): Form<SearchPrefill>) -> Response {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn search_result(mut session: WritableSession, Form(form): Form<SearchPrefill>) -> Response {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login").into_response();
     }
@@ -493,9 +495,9 @@ async fn search_result(session: ReadableSession, Form(form): Form<SearchPrefill>
         .get()).into_response();
 }
 
-async fn login_page(session: ReadableSession) -> Html<String> {
+async fn login_page(mut session: WritableSession) -> Html<String> {
     let con = &mut database::establish_connection();
-    let maybe_user_id = session.get::<i32>("user_id");
+    let maybe_user_id = get_user_id(session);
 
     let build_version = env!("VERGEN_GIT_SHA");
 
@@ -532,14 +534,15 @@ async fn my_login(mut session: WritableSession, Form(form): Form<Login>) -> Redi
 
     if verif.is_ok() {
         session.insert("user_id", maybe_user.as_ref().unwrap().id.unwrap());
+        session.insert(SESSION_VERSION_KEY, SESSION_VERSION);
     }
 
 
     return Redirect::to("/");
 }
 
-async fn edit_recipe_form(session: ReadableSession, Path(path): Path<i32>) -> Response {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn edit_recipe_form(mut session: WritableSession, Path(path): Path<i32>) -> Response {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login").into_response();
     }
@@ -606,8 +609,8 @@ struct PutRecipe {
     recipe_text: Option<String>
 }
 
-async fn put_recipe(session: ReadableSession, Path(path): Path<i32>, Form(form): Form<PutRecipe>) -> Redirect {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn put_recipe(mut session: WritableSession, Path(path): Path<i32>, Form(form): Form<PutRecipe>) -> Redirect {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login");
     }
@@ -737,8 +740,8 @@ async fn put_recipe(session: ReadableSession, Path(path): Path<i32>, Form(form):
     return Redirect::to(format!("/recipe/detail/{}", path).as_str())
 }
 
-async fn toggle_tried(session: ReadableSession, Path(path): Path<i32>) -> StatusCode {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn toggle_tried(mut session: WritableSession, Path(path): Path<i32>) -> StatusCode {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return StatusCode::UNAUTHORIZED;
     }
@@ -866,8 +869,8 @@ struct RecipeDetailQuery {
 }
 
 
-async fn recipe_detail(session: ReadableSession, Path(path): Path<i32>) -> Response {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn recipe_detail(mut session: WritableSession, Path(path): Path<i32>) -> Response {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login").into_response();
     }
@@ -900,8 +903,8 @@ struct PostComment {
     comment: String,
 }
 
-async fn post_comment(session: ReadableSession, Path(path): Path<i32>, Form(form): Form<PostComment>) -> Response {
-    let maybe_user_id = session.get::<i32>("user_id");
+async fn post_comment(mut session: WritableSession, Path(path): Path<i32>, Form(form): Form<PostComment>) -> Response {
+    let maybe_user_id = get_user_id(session);
     if maybe_user_id.is_none() {
         return Redirect::to("/login").into_response();
     }
@@ -927,6 +930,20 @@ async fn post_comment(session: ReadableSession, Path(path): Path<i32>, Form(form
     return Redirect::to(format!("/recipe/detail/{}", path).as_str()).into_response();
 }
 
+
+fn get_user_id(mut session: WritableSession) -> Option<i32> {
+    let maybe_user_id = session.get::<i32>("user_id");
+    if maybe_user_id.is_none() {
+        return None;
+    }
+    let same_version = session.get::<usize>(SESSION_VERSION_KEY).filter(|x| *x == SESSION_VERSION);
+    if same_version.is_none() {
+        info!("Outdated session, destroying session");
+        session.destroy();
+        return None;
+    }
+    return maybe_user_id;
+}
 
 fn query_course() {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@ pub mod templates;
 pub mod args;
 pub mod queries;
 pub mod strops;
+pub mod secret;
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,0 +1,22 @@
+use std::env;
+
+use dotenvy::dotenv;
+use hex::FromHex;
+use itertools::Itertools;
+use rand::Rng;
+
+pub fn get_secret() -> [u8; 128] {
+    dotenv().ok();
+    let raw = env::var("SECRET").ok()
+        .filter(|x| x.is_ascii())
+        .filter(|x| x.len() == 256);
+    if raw.is_some() {
+        let asdf = <[u8; 128]>::from_hex(raw.unwrap()).ok();
+        if asdf.is_some() {
+            return asdf.unwrap();
+        }
+    }
+
+
+    return rand::thread_rng().gen::<[u8; 128]>();
+}

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -3,20 +3,29 @@ use std::env;
 use dotenvy::dotenv;
 use hex::FromHex;
 use itertools::Itertools;
+use log::info;
 use rand::Rng;
 
 pub fn get_secret() -> [u8; 128] {
     dotenv().ok();
+    let maybe_secret = env::var("SECRET").ok();
+    if maybe_secret.is_none() {
+        info!("No SECRET found in environment variable, generating one");
+        return rand::thread_rng().gen::<[u8; 128]>();
+    }
+
     let raw = env::var("SECRET").ok()
         .filter(|x| x.is_ascii())
         .filter(|x| x.len() == 256);
+
     if raw.is_some() {
         let asdf = <[u8; 128]>::from_hex(raw.unwrap()).ok();
         if asdf.is_some() {
+            info!("Setting your SECRET variable");
             return asdf.unwrap();
         }
     }
-
+    info!("SECRET variable is a 128-byte hex-encoded secret");
 
     return rand::thread_rng().gen::<[u8; 128]>();
 }


### PR DESCRIPTION
# What

Longer-lived sessions based on a persistent secret and a cookie store 

# Why

- constantly entering the password is flipping annoying, see #40

# How to see

Take care to set the `SECRET` environment variable. You can generate a suitable secret by running e.g. `dd if=/dev/urandom bs=128 count=1 | od -w128 -A n -t x1 | sed 's/ *//g'`.

- Start test server
- Log in
- Restart server
- Check to see that you're still logged in