### PR TITLE
build argon2 with optimizations, even in dev build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ diesel_logger = "0.2.0"
 version = "0.8.5"
 features = ["min_const_gen"]
 
+[profile.dev.package.argon2]
+opt-level=3
+
 
 [[bin]]
 name = "import"


### PR DESCRIPTION
# What

The argon2 crate is now built with `opt-level=3` in dev builds of this package.

# Why

Login took about 10 seconds for me and made development painful, especially with non persistent cookie stores.

# How to test

- [x] Log in
- [x] See it's fast 