### PR TITLE
Allow longer sessions

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -6,6 +6,9 @@
     <input name="email" type="email"><br>
     <label for="password">Password</label>
     <input name="password" type="password"><br>
+    <label for="long">Stay logged in?</label>
+    <input name="long" type="checkbox"><br>
+
     <input type="submit" value="login">
 
 </form>


### PR DESCRIPTION
# What

Allow user to select a session that ends 20 years later. 

# Why

It's annoying to log in all the time. 


# How to test

The best way is to use the debugger and check whether the internal fields of the session expiry are written correctly.